### PR TITLE
dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test:unit": "jest",
     "test:e2e": "cypress run",
     "lint": "eslint src --fix",
-    "bootstrap4-sass-compat-shim": "sass-migrator division **/*.scss && file-ops fnr 'math.div' 'list.slash' node_modules/bootstrap/scss/mixins/_forms.scss && file-ops prepend '@use \"sass:list\";\n' -u node_modules/bootstrap/scss/mixins/_forms.scss",
+    "bootstrap4-sass-compat-shim": "sass-migrator division **/*.scss && file-ops fnr 'math.div' 'list.slash' -s node_modules/bootstrap/scss/mixins/_forms.scss && file-ops prepend '@use \"sass:list\";\n' -s -u node_modules/bootstrap/scss/mixins/_forms.scss",
     "postinstall": "yarn bootstrap4-sass-compat-shim"
   },
   "dependencies": {
@@ -39,7 +39,7 @@
     "vue-server-renderer": "^2.6.14"
   },
   "devDependencies": {
-    "@nrademacher/file-ops-cli": "^0.6.7",
+    "@nrademacher/file-ops-cli": "^0.6.8",
     "@types/jest": "^27.0.2",
     "@types/js-cookie": "^3.0.0",
     "@types/node": "^16.11.6",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "vue-tsc --noEmit && vite build",
     "test:unit": "jest",
     "test:e2e": "cypress run",
-    "lint": "eslint src --fix"
+    "lint": "eslint src --fix",
+    "bootstrap4-sass-compat-shim": "sass-migrator division **/*.scss && file-ops fnr 'math.div' 'list.slash' node_modules/bootstrap/scss/mixins/_forms.scss && file-ops prepend '@use \"sass:list\";\n' node_modules/bootstrap/scss/mixins/_forms.scss",
+    "postinstall": "yarn bootstrap4-sass-compat-shim"
   },
   "dependencies": {
     "@apollo/client": "^3.4.16",
@@ -22,7 +24,7 @@
     "apollo-link-http": "^1.5.17",
     "apollo-link-ws": "^1.0.20",
     "apollo-utilities": "^1.3.4",
-    "bootstrap": "^4.6.0",
+    "bootstrap": ">=4.5.3 <5.0.0",
     "bootstrap-vue": "^2.21.2",
     "graphql": "^15.6.1",
     "graphql-tag": "^2.12.5",
@@ -34,10 +36,10 @@
     "vue-class-component": "^7.2.6",
     "vue-property-decorator": "^9.1.2",
     "vue-router": "^3.2.0",
-    "vue-router-layout": "^0.4.0",
     "vue-server-renderer": "^2.6.14"
   },
   "devDependencies": {
+    "@nrademacher/file-ops-cli": "^2.5.5",
     "@types/jest": "^27.0.2",
     "@types/js-cookie": "^3.0.0",
     "@types/node": "^16.11.6",
@@ -55,7 +57,8 @@
     "eslint-plugin-vue": "^7.6.0",
     "jest": "^27.1.0",
     "prettier": "^2.2.1",
-    "sass": "^1.32.13",
+    "sass": "^1.32.12",
+    "sass-migrator": "^1.5.2",
     "ts-jest": "^27.0.7",
     "ts-node": "^10.4.0",
     "typescript": "^4.4.4",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test:unit": "jest",
     "test:e2e": "cypress run",
     "lint": "eslint src --fix",
-    "bootstrap4-sass-compat-shim": "sass-migrator division **/*.scss && file-ops fnr 'math.div' 'list.slash' node_modules/bootstrap/scss/mixins/_forms.scss && file-ops prepend '@use \"sass:list\";\n' node_modules/bootstrap/scss/mixins/_forms.scss",
+    "bootstrap4-sass-compat-shim": "sass-migrator division **/*.scss && file-ops fnr 'math.div' 'list.slash' node_modules/bootstrap/scss/mixins/_forms.scss && file-ops prepend '@use \"sass:list\";\n' -u node_modules/bootstrap/scss/mixins/_forms.scss",
     "postinstall": "yarn bootstrap4-sass-compat-shim"
   },
   "dependencies": {
@@ -39,7 +39,7 @@
     "vue-server-renderer": "^2.6.14"
   },
   "devDependencies": {
-    "@nrademacher/file-ops-cli": "^2.5.5",
+    "@nrademacher/file-ops-cli": "^0.6.7",
     "@types/jest": "^27.0.2",
     "@types/js-cookie": "^3.0.0",
     "@types/node": "^16.11.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -690,10 +690,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@nrademacher/file-ops-cli@^0.6.7":
-  version "0.6.7"
-  resolved "https://registry.yarnpkg.com/@nrademacher/file-ops-cli/-/file-ops-cli-0.6.7.tgz#f30f89d59380e943c69db10ef6360836a89d1e36"
-  integrity sha512-V9DDRw/peOi+69BJzUsrgc0pdFFMMIENXjy//ngYmfDAE9/oRkQvfuJBR5NwhB8pJpGHuTuP5zIvqvcxJZbdDQ==
+"@nrademacher/file-ops-cli@^0.6.8":
+  version "0.6.8"
+  resolved "https://registry.yarnpkg.com/@nrademacher/file-ops-cli/-/file-ops-cli-0.6.8.tgz#e48c0044952d92f76d165f9c470a6c9308b6094b"
+  integrity sha512-mfclSLWSShFh94D9NDLDcz+ehP/AJkEP51a6xIG7VHzEQaSP4FPN54bKmm66nkFt5sY0ut757QyECFyZZM4EgQ==
   dependencies:
     glob "^7.2.0"
     picocolors "^0.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -690,6 +690,16 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@nrademacher/file-ops-cli@^2.5.5":
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/@nrademacher/file-ops-cli/-/file-ops-cli-2.5.5.tgz#80692c9a140190b525cee76964e453639f477290"
+  integrity sha512-btwcY6/NltyApg6qwwDBOvc2p8W4oGqJ3KeHau9eGQC010gt0yacXYgZ/3jV39+r4u39QYrMX++TX+Tf/0uB9g==
+  dependencies:
+    glob "^7.2.0"
+    picocolors "^0.2.1"
+    replace "^1.2.1"
+    semver "^7.3.5"
+
 "@nuxt/opencollective@^0.3.2":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@nuxt/opencollective/-/opencollective-0.3.2.tgz#83cb70cdb2bac5fad6f8c93529e7b11187d49c02"
@@ -2216,7 +2226,7 @@ bootstrap-vue@^2.21.2:
     portal-vue "^2.1.7"
     vue-functional-data-merge "^3.1.0"
 
-"bootstrap@>=4.5.3 <5.0.0", bootstrap@^4.6.0:
+"bootstrap@>=4.5.3 <5.0.0":
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.6.0.tgz#97b9f29ac98f98dfa43bf7468262d84392552fd7"
   integrity sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw==
@@ -2327,6 +2337,15 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
 chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -2337,15 +2356,6 @@ chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
-
-chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
-  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
-  dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
 
 chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.2"
@@ -2426,6 +2436,15 @@ cli-truncate@^2.1.0:
   dependencies:
     slice-ansi "^3.0.0"
     string-width "^4.2.0"
+
+cliui@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"
+  integrity sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^6.2.0"
 
 cliui@^7.0.2:
   version "7.0.4"
@@ -2726,6 +2745,11 @@ debug@^3.1.0:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
+
+decamelize@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+  integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
 decimal.js@^10.2.1:
   version "10.3.1"
@@ -3478,7 +3502,7 @@ gensync@^1.0.0-beta.2:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
-get-caller-file@^2.0.5:
+get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -3535,7 +3559,7 @@ glob-parent@^5.1.2, glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
+glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -4805,7 +4829,7 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-minimatch@^3.0.4:
+minimatch@3.0.4, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -5455,6 +5479,15 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
+replace@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/replace/-/replace-1.2.1.tgz#e6e28db8dc7dcfa2a6c0b99c8922360570f1aead"
+  integrity sha512-KZCBe/tPanwBlbjSMQby4l+zjSiFi3CLEP/6VLClnRYgJ46DZ5u9tmA6ceWeFS8coaUnU4ZdGNb/puUGMHNSRg==
+  dependencies:
+    chalk "2.4.2"
+    minimatch "3.0.4"
+    yargs "^15.3.1"
+
 request-light@^0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/request-light/-/request-light-0.5.4.tgz#497a98c6d8ae49536417a5e2d7f383b934f3e38c"
@@ -5476,6 +5509,11 @@ require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
+require-main-filename@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
+  integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"
@@ -5568,10 +5606,15 @@ safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sass@^1.32.13:
-  version "1.43.3"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.43.3.tgz#aa16a69131b84f0cd23189a242571e8905f1ce43"
-  integrity sha512-BJnLngqWpMeS65UvlYYEuCb3/fLxDxhHtOB/gWPxs6NKrslTxGt3ZxwIvOe/0Jm4tWwM/+tIpE3wj4dLEhPDeQ==
+sass-migrator@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/sass-migrator/-/sass-migrator-1.5.2.tgz#a6a865e0fc74cb027dcc7b2aa7d029d48992bed0"
+  integrity sha512-PPriZrqP6Pg3BSm6BsQiHjI0wn9IpdrgsTCgkGEPvLeEQovP2ooF+e6b3nL+dFYKlxWXkPz4sJ87/lFPdOl4OA==
+
+sass@^1.32.12:
+  version "1.43.4"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.43.4.tgz#68c7d6a1b004bef49af0d9caf750e9b252105d1f"
+  integrity sha512-/ptG7KE9lxpGSYiXn7Ar+lKOv37xfWsZRtFYal2QHNigyVQDx685VFT/h7ejVr+R8w7H4tmUgtulsKl5YpveOg==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
 
@@ -5612,6 +5655,11 @@ serialize-javascript@^4.0.0:
   integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
   dependencies:
     randombytes "^2.1.0"
+
+set-blocking@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
+  integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -6445,11 +6493,6 @@ vue-property-decorator@^9.1.2:
   resolved "https://registry.yarnpkg.com/vue-property-decorator/-/vue-property-decorator-9.1.2.tgz#266a2eac61ba6527e2e68a6933cfb98fddab5457"
   integrity sha512-xYA8MkZynPBGd/w5QFJ2d/NM0z/YeegMqYTphy7NJQXbZcuU6FC6AOdUAcy4SXP+YnkerC6AfH+ldg7PDk9ESQ==
 
-vue-router-layout@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/vue-router-layout/-/vue-router-layout-0.4.0.tgz#0d159fc8b11fb23a0edc403f466e43ebdf0bd846"
-  integrity sha512-yesegYKAjI6pLv1imzWIHYLOZ45YFrIeMk3cX0EBa5hI9pd86JeudBTuBhMNr7otG/M30iBY0sS+sD2ooDrurA==
-
 vue-router@^3.2.0:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.5.2.tgz#5f55e3f251970e36c3e8d88a7cd2d67a350ade5c"
@@ -6560,6 +6603,11 @@ whatwg-url@^8.0.0, whatwg-url@^8.5.0:
     tr46 "^2.1.0"
     webidl-conversions "^6.1.0"
 
+which-module@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
+  integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
+
 which@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
@@ -6630,6 +6678,11 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
+y18n@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
+  integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
+
 y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
@@ -6649,6 +6702,31 @@ yargs-parser@20.x, yargs-parser@^20.2.2:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
+
+yargs-parser@^18.1.2:
+  version "18.1.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
+  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs@^15.3.1:
+  version "15.4.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
+  integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^18.1.2"
 
 yargs@^16.2.0:
   version "16.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -690,15 +690,14 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@nrademacher/file-ops-cli@^2.5.5":
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/@nrademacher/file-ops-cli/-/file-ops-cli-2.5.5.tgz#80692c9a140190b525cee76964e453639f477290"
-  integrity sha512-btwcY6/NltyApg6qwwDBOvc2p8W4oGqJ3KeHau9eGQC010gt0yacXYgZ/3jV39+r4u39QYrMX++TX+Tf/0uB9g==
+"@nrademacher/file-ops-cli@^0.6.7":
+  version "0.6.7"
+  resolved "https://registry.yarnpkg.com/@nrademacher/file-ops-cli/-/file-ops-cli-0.6.7.tgz#f30f89d59380e943c69db10ef6360836a89d1e36"
+  integrity sha512-V9DDRw/peOi+69BJzUsrgc0pdFFMMIENXjy//ngYmfDAE9/oRkQvfuJBR5NwhB8pJpGHuTuP5zIvqvcxJZbdDQ==
   dependencies:
     glob "^7.2.0"
     picocolors "^0.2.1"
     replace "^1.2.1"
-    semver "^7.3.5"
 
 "@nuxt/opencollective@^0.3.2":
   version "0.3.2"


### PR DESCRIPTION
- chore: extract login page logo composite into component
- chore: extract apollo setup from main.ts
- chore: convert js config files to json + use ts-jest
- chore: remove vuex (in favor of apollo cache)
- feat: add light/dark mode switch
- chore: more component modularization
- chore: adopt logos for mode switching
- chore: move route components into views
- chore: switch to vite
- chore: add bootstrap 4 sass compat script to get rid of warnings
- chore(devDeps): update file-ops-cli for bs4 shim command
- chore: update file-ops-cli for silent flag
